### PR TITLE
add lesson 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Learn How to Effectively Use the GitHub Copilot Family of Tools.
 - [Lesson 5: DevOps with GitHub Copilot](docs/lesson5.md)
 - [Lesson 6: Implementing Code Improvements with GitHub Copilot](docs/lesson6.md)
 - [Lesson 7: Prompting Techniques](docs/lesson7.md)
-- [Lesson 8: Guided Project](docs/lesson8.md)
 
 ## Directory Structure
 

--- a/docs/lesson3.md
+++ b/docs/lesson3.md
@@ -77,7 +77,10 @@ Provide a short description of the task or feature being demonstrated.
    ```
 
 **Expected Outcome:**  
-The existing and new unit tests should pass. If some test cases fail, you can use GitHub Copilot to fix the code or the failing unit tests.
+The existing and new unit tests should pass. If some test cases fail, you can use GitHub Copilot to fix the code or the failing unit tests.  
+
+**NOTE**:  Generated code may not be correct as GitHub Copilot context grasp is limited and may use incorrect assumptions.  In general, it will correctly identify the testing framework for the project.  
+Use your skills and GitHub Copilot to resolve the issue by varying your prompts and focus in an iterative manner.  
 
 ---
 
@@ -99,7 +102,10 @@ In this step, you will use GitHub Copilot to create an new integration tests pro
    ```
 
 **Expected Outcome:**  
-Newly created tests should pass. If some test cases fail, you can use GitHub Copilot to fix the code or the failing tests.
+Newly created tests should pass. If some test cases fail, you can use GitHub Copilot to fix the code or the failing tests.  
+
+**NOTE**:  Generated code may not be correct as GitHub Copilot context grasp is limited and may use incorrect assumptions.  In general, it will correctly identify the testing framework and mocking library for the project.  
+Use your skills and GitHub Copilot to resolve the issue by varying your prompts and focus in an iterative manner.  
 
 ---
 

--- a/docs/lesson4.md
+++ b/docs/lesson4.md
@@ -1,0 +1,125 @@
+
+# Hands-On Lab: Creating Documentation with GitHub Copilot
+
+## Overview
+
+**Goal:**  
+By the end of this session, you will learn basics of how GitHub Copilot can help with generating inline comments and project documentation.
+
+**Estimated Duration:**  
+[Time in minutes/hours]
+
+**Audience:**  
+[developers, ops, testers, etc.]
+
+**Prerequisites:**  
+- Completed [Lesson 1: Installing and Configuring GitHub Copilot](docs/lesson1.md), or
+- Access to GitHub Copilot (subscription),
+- Visual Studio Code,
+- GitHub Copilot extension to VS Code.  
+---
+
+## Table of Contents
+1. [Lab Objectives](#lab-objectives)
+2. [Environment Setup](#environment-setup)
+3. [Walkthrough](#walkthrough)
+    - [Step 1: Generate Inline Comments](#step-1-generate-inline-comments)
+    - [Step 2: Generate Project Documentation](#step-2-generate-project-documentation)
+5. [Troubleshooting](#troubleshooting)
+6. [Conclusion](#conclusion)
+
+---
+
+## Lab Objectives
+
+- Understand how to leverage GitHub Copilot to add code comments and document your projects.  
+
+---
+
+## Environment Setup
+
+### Tools and Resources
+- GitHub Copilot enabled on your GitHub account.
+- Visual Studio Code with GitHub Copilot extension installed.
+- Code repository for the lab: [GitHub Copilot](https://github.com/neudesic/learning-github-copilot).
+
+### Steps to Prepare
+1. Clone the repository:  
+   ```bash
+   git clone https://github.com/neudesic/learning-github-copilot.git
+   cd learning-github-copilot/samples/eShop
+   ```
+2. Open the project in your IDE:  
+   ```bash
+   code .
+   ```
+
+---
+
+## Walkthrough
+
+### Step 1: Generate Inline Comments
+**Description:**  
+In this step, we will use o1-mini model and Copilot Edits to generate inline comments.  
+
+**Instructions:**  
+1. In VS Code, open file **src/Basket.API/Grps/BasketService.cs**
+2. Open Copilot Edits by pressing Ctrl-Shift-I.
+3. Observe that BasketService.cs file is already in the Working Set. (1 file).  
+You can manage the Working Set by adding and removing files.
+4. In the command bar area at the bottom, click model selection at the right corner and select **o1-mini (Preview)**.  
+We will use faster o1-mini model.
+5. In the prompt field, enter "add comments" and press Enter.  
+GitHub Copilot confirms the plan to add simple inline comments to the code and proceeds with applying the edits to the file.
+6. Click **Discard** button.  
+All edits will be discarded.  We wanted XML comments!
+7. In the prompt field, enter "add xml comments" and press Enter.  
+GitHub Copilot confirms the plan to add XML Comments to the class and public methods and proceeds with applying the edits to the file.
+responds with suggested XML comments for each function in the class.
+8. (Optional) In the prompt field, enter "add comments to private methods as well" and press Enter.
+GitHub Copilot confirms the plan to add XML Comments to the private methods as well and proceeds with applying the edits to the file.
+9. Click **Accept** button and save the file.
+
+
+**Expected Outcome:**  
+GitHub Copilot generates comments based on the code you provide and your prompt. While the generated comments **can** be accurate and useful responses, it's important to review and correct the generated output to ensure it has desired qualities.
+
+---
+
+### Step 2: Generate Project Documentation
+**Description:**  
+In this step, we will use o1-preview model and Copilot Edits to generate project documentation.  
+
+**Instructions:**  
+1. Open Copilot Edits by pressing Ctrl-Shift-I.
+2. In the command bar area at the bottom, ensure that model **o1-mini (Preview)** is selected.  
+We will use faster o1-mini model.
+3. In the prompt field, enter "Generate solution documentation that can be used at an executive briefing. Save it as TLDR.md file" and press Enter.  
+GitHub Copilot confirms the plan and creates requested documentation to the TLDR.ms file.
+4. Observe the content of the file. You can open the file preview by pressing Ctrl-Shift-V. 
+5. In the prompt field, enter "add dependencies, please" and press Enter.  
+GitHub Copilot confirms the plan and adds dependencies under Technical Overview.
+6. Click **Accept** button and save the file.
+
+
+**Expected Outcome:**  
+GitHub Copilot generated requested executive briefing and you were able to modify it an iterative manner using natural language prompts.  
+While the generated comments **can** be accurate and useful responses, it's important to review and and ensure it is accurate and made according to the responsible AI principles, e.g. [Responsible AI with GitHub Copilot](https://learn.microsoft.com/en-us/training/modules/responsible-ai-with-github-copilot/).  
+
+---
+
+## Troubleshooting
+
+- **Generated response is truncated or looks incomplete:** LLM models have finite set of tokens to use which includes current scope and previous prompts.  
+  **Solution:** You may try selecting a different model, or try clearing previous context (if it is irrelevant to the current prompt). Use /clear command.  
+
+---
+
+## Conclusion
+
+**Summary:**  
+In this lab you have learned how you can work with GitHub Copilot to better understand and document your solutions.  
+
+**Next Steps:**  
+- [Lesson 5: DevOps with GitHub Copilot](docs/lesson5.md)
+


### PR DESCRIPTION
This pull request includes several updates to the documentation for GitHub Copilot lessons, including adding a new lesson, providing additional guidance on using GitHub Copilot, and updating existing lesson content. The most important changes include the addition of a new hands-on lab, updates to lesson instructions, and the inclusion of notes to clarify the limitations of GitHub Copilot-generated code.

New lesson addition:

* [`docs/lesson4.md`](diffhunk://#diff-9136112a358b4a3ccbc21a9cda9eacab8410ae1bc363773cc815ca52638886e5R1-R125): Added a new hands-on lab titled "Creating Documentation with GitHub Copilot," which includes an overview, objectives, environment setup, and step-by-step walkthroughs for generating inline comments and project documentation.

Updates to existing lessons:

* [`docs/lesson3.md`](diffhunk://#diff-de99ba2d495360a793d3e0daacc4b4b6e271ccce4f5232a8cbeeb144ae869033R82-R84): Added notes to emphasize that generated code may not always be correct due to GitHub Copilot's limited context grasp and provided guidance on using iterative prompts to resolve issues. [[1]](diffhunk://#diff-de99ba2d495360a793d3e0daacc4b4b6e271ccce4f5232a8cbeeb144ae869033R82-R84) [[2]](diffhunk://#diff-de99ba2d495360a793d3e0daacc4b4b6e271ccce4f5232a8cbeeb144ae869033R107-R109)

Removal of outdated content:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23): Removed the link to "Lesson 8: Guided Project" from the lesson list, as it is no longer part of the curriculum.